### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/PollySandbox/Clients/MoviesClient.cs
+++ b/src/PollySandbox/Clients/MoviesClient.cs
@@ -24,7 +24,7 @@ public class MoviesClient : ApiClient, IMoviesClient
     public async Task<IList<Movie>> GetMoviesAsync(CancellationToken cancellationToken)
     {
         return await ExecuteAsync(
-            GetTokenForRateLimit(HttpContextAccessor.HttpContext.Request.Headers.UserAgent),
+            GetTokenForRateLimit(HttpContextAccessor.HttpContext?.Request.Headers.UserAgent),
             ContextPrefix + nameof(GetMoviesAsync),
             _client.GetAsync,
             cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fix `NullReferenceException` when running the microbenchmarks and there's no `HttpContext`.
