### PR TITLE
Use StatusCodes and add OperationPrefix

### DIFF
--- a/src/PollySandbox/Clients/ApiClient.cs
+++ b/src/PollySandbox/Clients/ApiClient.cs
@@ -27,6 +27,8 @@ public abstract class ApiClient
 
     protected ILogger Logger { get; }
 
+    protected abstract string OperationPrefix { get; }
+
     protected ApiOptions Options { get; }
 
     protected PolicyFactory PolicyFactory { get; }
@@ -97,7 +99,7 @@ public abstract class ApiClient
         Func<Context, CancellationToken, Task<TResult>> action,
         CancellationToken cancellationToken)
     {
-        var context = new Context(operationKey);
+        var context = new Context($"{OperationPrefix}.{operationKey}");
 
         if (clientExecuteOptions?.HandleExecutionFaults.HasValue == true)
         {

--- a/src/PollySandbox/Clients/MoviesClient.cs
+++ b/src/PollySandbox/Clients/MoviesClient.cs
@@ -5,7 +5,6 @@ namespace PollySandbox;
 
 public class MoviesClient : ApiClient, IMoviesClient
 {
-    private const string ContextPrefix = "movies.";
     private readonly IMoviesApi _client;
 
     public MoviesClient(
@@ -21,11 +20,13 @@ public class MoviesClient : ApiClient, IMoviesClient
 
     protected override ApiEndpointOption EndpointOption => Options.MoviesEndpoint();
 
+    protected override string OperationPrefix => "Movies";
+
     public async Task<IList<Movie>> GetMoviesAsync(CancellationToken cancellationToken)
     {
         return await ExecuteAsync(
             GetTokenForRateLimit(HttpContextAccessor.HttpContext?.Request.Headers.UserAgent),
-            ContextPrefix + nameof(GetMoviesAsync),
+            nameof(GetMoviesAsync),
             _client.GetAsync,
             cancellationToken).ConfigureAwait(false);
     }
@@ -39,7 +40,7 @@ public class MoviesClient : ApiClient, IMoviesClient
 
         return await ExecuteAsync(
             GetTokenForRateLimit(id),
-            ContextPrefix + nameof(GetMovieAsync),
+            nameof(GetMovieAsync),
             token => _client.GetAsync(id, token),
             executionOptions,
             cancellationToken).ConfigureAwait(false);

--- a/src/PollySandbox/Clients/UsersClient.cs
+++ b/src/PollySandbox/Clients/UsersClient.cs
@@ -5,7 +5,6 @@ namespace PollySandbox;
 
 public class UsersClient : ApiClient, IUsersClient
 {
-    private const string ContextPrefix = "users.";
     private readonly IUsersApi _client;
 
     public UsersClient(
@@ -21,11 +20,13 @@ public class UsersClient : ApiClient, IUsersClient
 
     protected override ApiEndpointOption EndpointOption => Options.UsersEndpoint();
 
+    protected override string OperationPrefix => "Users";
+
     public async Task<IList<User>> GetUsersAsync(CancellationToken cancellationToken)
     {
         return await ExecuteAsync(
             GetTokenForRateLimit(HttpContextAccessor.HttpContext.Request.Headers.UserAgent),
-            ContextPrefix + nameof(GetUsersAsync),
+            nameof(GetUsersAsync),
             _client.GetAsync,
             cancellationToken).ConfigureAwait(false);
     }
@@ -39,7 +40,7 @@ public class UsersClient : ApiClient, IUsersClient
 
         return await ExecuteAsync(
             GetTokenForRateLimit(id),
-            ContextPrefix + nameof(GetUserAsync),
+            nameof(GetUserAsync),
             token => _client.GetAsync(id, token),
             executionOptions,
             cancellationToken).ConfigureAwait(false);

--- a/src/PollySandbox/Program.cs
+++ b/src/PollySandbox/Program.cs
@@ -25,11 +25,11 @@ app.MapGet("/movies", async (IMoviesClient client, CancellationToken cancellatio
     }
     catch (RateLimitRejectedException)
     {
-        return Results.StatusCode(429);
+        return Results.StatusCode(StatusCodes.Status429TooManyRequests);
     }
     catch (ExecutionRejectedException)
     {
-        return Results.StatusCode(500);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 });
 
@@ -42,11 +42,11 @@ app.MapGet("/movies/{id}", async (string id, IMoviesClient client, CancellationT
     }
     catch (RateLimitRejectedException)
     {
-        return Results.StatusCode(429);
+        return Results.StatusCode(StatusCodes.Status429TooManyRequests);
     }
     catch (ExecutionRejectedException)
     {
-        return Results.StatusCode(500);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 });
 
@@ -58,11 +58,11 @@ app.MapGet("/users", async (IUsersClient client, CancellationToken cancellationT
     }
     catch (RateLimitRejectedException)
     {
-        return Results.StatusCode(429);
+        return Results.StatusCode(StatusCodes.Status429TooManyRequests);
     }
     catch (ExecutionRejectedException)
     {
-        return Results.StatusCode(500);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 });
 
@@ -75,11 +75,11 @@ app.MapGet("/users/{id}", async (string id, IUsersClient client, CancellationTok
     }
     catch (RateLimitRejectedException)
     {
-        return Results.StatusCode(429);
+        return Results.StatusCode(StatusCodes.Status429TooManyRequests);
     }
     catch (ExecutionRejectedException)
     {
-        return Results.StatusCode(500);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 });
 
@@ -97,7 +97,7 @@ app.MapGet("/reload", (IConfiguration config, PolicyStore policyStore, IMemoryCa
     }
 
     return Results.Ok();
-}).ExcludeFromDescription();
+});
 
 app.Run();
 


### PR DESCRIPTION
- Use the `StatusCodes` constants.
- Remove `ExcludeFromDescription()`.
- Add `OperationPrefix` property to simplify the client code.
