### PR TITLE
Update dependencies

### DIFF
--- a/perf/PollySandbox.Benchmarks/PollySandbox.Benchmarks.csproj
+++ b/perf/PollySandbox.Benchmarks/PollySandbox.Benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
   </ItemGroup>

--- a/src/PollySandbox/PollySandbox.csproj
+++ b/src/PollySandbox/PollySandbox.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Polly" Version="8.0.0-alpha.5" />
+    <PackageReference Include="Polly" Version="8.0.0-alpha.7" />
     <PackageReference Include="Refit" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Bump Polly to 8.0.0-alpha.7.
- Bump BenchmarkDotNet to 0.13.7.
