### PR TITLE
Bump Polly to 8.0.0-alpha.8

### DIFF
--- a/src/PollySandbox/PollySandbox.csproj
+++ b/src/PollySandbox/PollySandbox.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Polly" Version="8.0.0-alpha.7" />
+    <PackageReference Include="Polly" Version="8.0.0-alpha.8" />
     <PackageReference Include="Refit" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/PollySandbox.Tests/PollySandbox.Tests.csproj
+++ b/tests/PollySandbox.Tests/PollySandbox.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Moq" Version="4.20.1" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />


### PR DESCRIPTION
- Update to the latest Polly v8 alpha.
- Update Moq and test SDK to their latest versions.
