### PR TITLE
Use BenchmarkDotNet VSTest integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
+    BenchmarkDotNet:
+      patterns:
+        - BenchmarkDotNet*
     xunit:
       patterns:
         - xunit*

--- a/perf/PollySandbox.Benchmarks/PollySandbox.Benchmarks.csproj
+++ b/perf/PollySandbox.Benchmarks/PollySandbox.Benchmarks.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <GenerateProgramFile>false</GenerateProgramFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,8 +8,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\PollySandbox\PollySandbox.csproj" />


### PR DESCRIPTION
Add support for using the [VSTest integration](https://benchmarkdotnet.org/articles/features/vstest.html) to run the benchmarks.
